### PR TITLE
fix: configure GraphQL category to use index.md as category page

### DIFF
--- a/docs/5-graphql/_category_.json
+++ b/docs/5-graphql/_category_.json
@@ -2,7 +2,7 @@
     "label": "GraphQL Operations: Queries & Mutations",
     "position": 5,
     "link": {
-        "type": "generated-index",
-        "description": "Explore the core concepts of GraphQL operations, including queries and mutations. Learn how to define and execute these operations to interact with your GraphQL API effectively."
+        "type": "doc",
+        "id": "5-graphql/index"
     }
 }


### PR DESCRIPTION
- Changed link type from 'generated-index' to 'doc'
- This makes index.md serve as the category landing page
- Removes duplicate index.md entry from sidebar navigation