### PR TITLE
Fix Safari hero/sidebar rendering issues

### DIFF
--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -146,11 +146,13 @@
     bottom: 0;
     width: 80%;
     max-width: 350px;
-    background: white;
+    background-color: #ffffff;
     z-index: 100;
     transform: translateX(-100%);
     transition: transform 0.3s ease;
     padding: 1rem 1.5rem;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
   }
 
   .heroSidebarOpen {
@@ -251,10 +253,6 @@
   align-items: center;
 }
 
-.heroBanner.hero {
-  padding: 0;
-  background-color: transparent !important;
-}
 
 .heroBanner :global(.hero__title) {
   font-family: 'Quicksand' !important;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import {type ReactNode, useState, useEffect} from 'react';
+import {type ReactNode, useState, useEffect, useRef} from 'react';
 import clsx from 'clsx';
 import Link from '@docusaurus/Link';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
@@ -28,50 +28,52 @@ function HeroNavbar() {
   }, []);
 
   return (
-    <nav className={clsx(styles.heroNav, scrolled && styles.heroNavScrolled)}>
-      <div className={styles.heroNavInner}>
-        {/* Mobile: hamburger toggle */}
-        <button
-          className={styles.heroNavToggle}
-          onClick={() => setSidebarOpen(!sidebarOpen)}
-          aria-label="Toggle navigation"
-        >
-          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
-            <line x1="3" y1="6" x2="21" y2="6" />
-            <line x1="3" y1="12" x2="21" y2="12" />
-            <line x1="3" y1="18" x2="21" y2="18" />
-          </svg>
-        </button>
+    <>
+      <nav className={clsx(styles.heroNav, scrolled && styles.heroNavScrolled)}>
+        <div className={styles.heroNavInner}>
+          {/* Mobile: hamburger toggle */}
+          <button
+            className={styles.heroNavToggle}
+            onClick={() => setSidebarOpen(!sidebarOpen)}
+            aria-label="Toggle navigation"
+          >
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+              <line x1="3" y1="6" x2="21" y2="6" />
+              <line x1="3" y1="12" x2="21" y2="12" />
+              <line x1="3" y1="18" x2="21" y2="18" />
+            </svg>
+          </button>
 
-        <div className={styles.heroNavLeft}>
-          <Link to="/" className={styles.heroNavLogo}>
+          <div className={styles.heroNavLeft}>
+            <Link to="/" className={styles.heroNavLogo}>
+              <img src="/img/logo-circle.svg" alt="Hugr Lab" />
+            </Link>
+            <Link to="/docs/overview/" className={styles.heroNavLink}>Docs</Link>
+            <Link to="/docs/join-us/" className={styles.heroNavLink}>Join us</Link>
+          </div>
+
+          {/* Mobile: logo on the right */}
+          <Link to="/" className={styles.heroNavLogoMobile}>
             <img src="/img/logo-circle.svg" alt="Hugr Lab" />
           </Link>
-          <Link to="/docs/overview/" className={styles.heroNavLink}>Docs</Link>
-          <Link to="/docs/join-us/" className={styles.heroNavLink}>Join us</Link>
+
+          <div className={styles.heroNavRight}>
+            <Link
+              to="https://github.com/hugr-lab/hugr"
+              className={clsx(styles.heroNavLink, styles.heroNavExternal)}
+            >
+              GitHub
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" style={{marginLeft: '0.3rem'}}>
+                <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+                <polyline points="15 3 21 3 21 9" />
+                <line x1="10" y1="14" x2="21" y2="3" />
+              </svg>
+            </Link>
+          </div>
         </div>
+      </nav>
 
-        {/* Mobile: logo on the right */}
-        <Link to="/" className={styles.heroNavLogoMobile}>
-          <img src="/img/logo-circle.svg" alt="Hugr Lab" />
-        </Link>
-
-        <div className={styles.heroNavRight}>
-          <Link
-            to="https://github.com/hugr-lab/hugr"
-            className={clsx(styles.heroNavLink, styles.heroNavExternal)}
-          >
-            GitHub
-            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" style={{marginLeft: '0.3rem'}}>
-              <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
-              <polyline points="15 3 21 3 21 9" />
-              <line x1="10" y1="14" x2="21" y2="3" />
-            </svg>
-          </Link>
-        </div>
-      </div>
-
-      {/* Mobile sidebar */}
+      {/* Mobile sidebar — outside nav to avoid Safari fixed-in-fixed issues */}
       {sidebarOpen && (
         <div className={styles.heroSidebarBackdrop} onClick={() => setSidebarOpen(false)} />
       )}
@@ -97,13 +99,14 @@ function HeroNavbar() {
           <Link to="https://github.com/hugr-lab/hugr" className={styles.heroSidebarLink} onClick={() => setSidebarOpen(false)}>GitHub</Link>
         </div>
       </div>
-    </nav>
+    </>
   );
 }
 
 function HomepageHeader() {
   const {siteConfig} = useDocusaurusContext();
   const [isDesktop, setIsDesktop] = useState(false);
+  const videoRef = useRef<HTMLVideoElement>(null);
 
   useEffect(() => {
     const mql = window.matchMedia('(min-width: 997px)');
@@ -113,10 +116,17 @@ function HomepageHeader() {
     return () => mql.removeEventListener('change', handler);
   }, []);
 
+  useEffect(() => {
+    if (isDesktop && videoRef.current) {
+      videoRef.current.play().catch(() => {});
+    }
+  }, [isDesktop]);
+
   return (
     <header className={clsx('hero', styles.heroBanner)}>
       {isDesktop && (
         <video
+          ref={videoRef}
           className={styles.heroVideo}
           autoPlay
           muted


### PR DESCRIPTION
## Summary
- Fix transparent strip between hero and next section on Safari mobile (CSS specificity conflict)
- Fix sidebar background transparency in Safari by moving it out of fixed nav element
- Add programmatic `video.play()` for Safari autoplay reliability

## Test plan
- [ ] Safari mobile: no color strip between hero and DescriptionSection
- [ ] Safari mobile: sidebar has solid white background when opened
- [ ] Desktop: hero video autoplays in Safari
- [ ] Chrome: all existing functionality unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)