### PR TITLE
Add contact email to impressum and footer

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -159,8 +159,12 @@ const config: Config = {
           ],
         },
         {
-          title: 'Legal',
+          title: 'Contact',
           items: [
+            {
+              label: 'info@hugr-lab.com',
+              href: 'mailto:info@hugr-lab.com',
+            },
             {
               label: 'Impressum',
               to: '/impressum/',

--- a/src/pages/impressum.tsx
+++ b/src/pages/impressum.tsx
@@ -13,6 +13,10 @@ export default function Impressum(): ReactNode {
           Germany
         </p>
         <p>
+          <strong>Contact:</strong><br />
+          <a href="mailto:info@hugr-lab.com">info@hugr-lab.com</a>
+        </p>
+        <p>
           <strong>LinkedIn:</strong><br />
           <a href="https://www.linkedin.com/in/vladimirgribanov/" target="_blank" rel="noopener noreferrer">linkedin.com/in/vladimirgribanov</a>
         </p>


### PR DESCRIPTION
## Summary
- Add info@hugr-lab.com contact to impressum page
- Add contact section with email to footer (renamed "Legal" → "Contact")

🤖 Generated with [Claude Code](https://claude.com/claude-code)