### PR TITLE
Update Impressum and add Datenschutzerklärung

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,4 @@ yarn-error.log*
 .specify
 .claude
 future-spec/
-specs
+specs/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,10 @@
 Auto-generated from all feature plans. Last updated: 2026-02-08
 
 ## Active Technologies
+- TypeScript 5.6, MDX/Markdown + Docusaurus 3.8.0, React 19, RemoteMarkdown component, @theme/Tabs, @theme/TabItem (002-mssql-azure-docs)
+- N/A (static documentation site) (002-mssql-azure-docs)
+- TypeScript 5.6, React 19.0 + Docusaurus 3.8.0, `@theme/Layout` (004-impressum-datenschutz)
+- N/A (static content pages) (004-impressum-datenschutz)
 
 - TypeScript 5.6, React 19.0 + Docusaurus 3.8.0, CSS Modules, clsx (001-homepage-improvements)
 
@@ -22,6 +26,8 @@ npm test && npm run lint
 TypeScript 5.6, React 19.0: Follow standard conventions
 
 ## Recent Changes
+- 004-impressum-datenschutz: Added TypeScript 5.6, React 19.0 + Docusaurus 3.8.0, `@theme/Layout`
+- 002-mssql-azure-docs: Added TypeScript 5.6, MDX/Markdown + Docusaurus 3.8.0, React 19, RemoteMarkdown component, @theme/Tabs, @theme/TabItem
 
 - 001-homepage-improvements: Added TypeScript 5.6, React 19.0 + Docusaurus 3.8.0, CSS Modules, clsx
 

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -169,6 +169,10 @@ const config: Config = {
               label: 'Impressum',
               to: '/impressum/',
             },
+            {
+              label: 'Datenschutz',
+              to: '/datenschutz/',
+            },
           ],
         },
       ],

--- a/src/pages/datenschutz.tsx
+++ b/src/pages/datenschutz.tsx
@@ -1,0 +1,149 @@
+import type {ReactNode} from 'react';
+import Layout from '@theme/Layout';
+
+export default function Datenschutz(): ReactNode {
+  return (
+    <Layout
+      title="Datenschutzerklärung"
+      description="Datenschutzerklärung – Informationen zur Verarbeitung personenbezogener Daten">
+      <main style={{padding: '4rem 2rem', maxWidth: '800px', margin: '0 auto'}}>
+        <h1>Datenschutzerklärung</h1>
+
+        <h2>1. Verantwortlicher</h2>
+        <p>Verantwortlich für die Datenverarbeitung auf dieser Website:</p>
+        <p>
+          Vladimir Gribanov<br />
+          Filderstr. 54<br />
+          70771 Leinfelden-Echterdingen<br />
+          Deutschland
+        </p>
+        <p>
+          <strong>E-Mail:</strong>{' '}
+          <a href="mailto:info@hugr-lab.com">info@hugr-lab.com</a>
+        </p>
+
+        <hr />
+
+        <h2>2. Hosting über GitHub Pages</h2>
+        <p>
+          Diese Website wird über <strong>GitHub Pages</strong>, einen Dienst der GitHub
+          Inc., 88 Colin P. Kelly Jr. Street, San Francisco, CA 94107, USA, bereitgestellt.
+        </p>
+        <p>
+          Beim Aufruf der Website verarbeitet GitHub automatisch technische Zugriffsdaten
+          (Server-Logfiles), insbesondere:
+        </p>
+        <ul>
+          <li>IP-Adresse</li>
+          <li>Datum und Uhrzeit der Anfrage</li>
+          <li>Browsertyp und -version</li>
+          <li>Betriebssystem</li>
+          <li>Referrer URL</li>
+        </ul>
+        <p>
+          Die Verarbeitung erfolgt zur Bereitstellung und Sicherheit der Website (Art. 6
+          Abs. 1 lit. f DSGVO — berechtigtes Interesse an sicherem Betrieb).
+        </p>
+        <p>
+          GitHub kann diese Daten in die USA übertragen. Die Übermittlung erfolgt auf
+          Grundlage von Standardvertragsklauseln (Art. 46 Abs. 2 lit. c DSGVO).
+        </p>
+        <p>
+          Weitere Informationen:{' '}
+          <a
+            href="https://docs.github.com/en/site-policy/privacy-policies/github-privacy-statement"
+            target="_blank"
+            rel="noopener noreferrer">
+            GitHub Privacy Statement
+          </a>
+        </p>
+
+        <hr />
+
+        <h2>3. Keine Cookies / kein Tracking</h2>
+        <p>
+          Diese Website verwendet <strong>keine Cookies</strong> und{' '}
+          <strong>keine Tracking- oder Analyse-Tools</strong>.
+        </p>
+        <p>
+          Es findet kein Nutzer-Tracking, kein Profiling und keine Auswertung des
+          Nutzerverhaltens durch den Betreiber statt.
+        </p>
+
+        <hr />
+
+        <h2>4. Kontakt per E-Mail</h2>
+        <p>
+          Wenn Sie uns per E-Mail kontaktieren, werden Ihre Angaben inklusive der von Ihnen
+          dort angegebenen Kontaktdaten zur Bearbeitung der Anfrage gespeichert.
+        </p>
+        <p>
+          Die Verarbeitung erfolgt gemäß Art. 6 Abs. 1 lit. f DSGVO (berechtigtes
+          Interesse an Kommunikation).
+        </p>
+        <p>
+          Die Daten werden gelöscht, sobald sie für den Zweck ihrer Erhebung nicht mehr
+          erforderlich sind und keine gesetzlichen Aufbewahrungspflichten bestehen.
+        </p>
+
+        <hr />
+
+        <h2>5. Links zu externen Diensten</h2>
+        <p>
+          Diese Website enthält Links zu externen Plattformen, insbesondere GitHub. Beim
+          Anklicken eines solchen Links verlassen Sie diese Website.
+        </p>
+        <p>
+          Für die Datenverarbeitung durch diese Dienste gelten ausschließlich deren
+          Datenschutzbestimmungen.
+        </p>
+
+        <hr />
+
+        <h2>6. Ihre Rechte</h2>
+        <p>Sie haben gemäß DSGVO folgende Rechte:</p>
+        <ul>
+          <li>
+            <strong>Auskunft</strong> über gespeicherte Daten (Art. 15 DSGVO)
+          </li>
+          <li>
+            <strong>Berichtigung</strong> unrichtiger Daten (Art. 16 DSGVO)
+          </li>
+          <li>
+            <strong>Löschung</strong> (Art. 17 DSGVO)
+          </li>
+          <li>
+            <strong>Einschränkung</strong> der Verarbeitung (Art. 18 DSGVO)
+          </li>
+          <li>
+            <strong>Datenübertragbarkeit</strong> (Art. 20 DSGVO)
+          </li>
+          <li>
+            <strong>Widerspruch</strong> gegen die Verarbeitung (Art. 21 DSGVO)
+          </li>
+        </ul>
+        <p>Zur Ausübung genügt eine formlose Mitteilung per E-Mail.</p>
+
+        <hr />
+
+        <h2>7. Beschwerderecht bei Aufsichtsbehörde</h2>
+        <p>
+          Sie haben das Recht, sich bei einer Datenschutz-Aufsichtsbehörde zu beschweren.
+        </p>
+        <p>
+          <strong>
+            Landesbeauftragter für den Datenschutz und die Informationsfreiheit
+            Baden-Württemberg
+          </strong>
+          <br />
+          <a
+            href="https://www.baden-wuerttemberg.datenschutz.de"
+            target="_blank"
+            rel="noopener noreferrer">
+            https://www.baden-wuerttemberg.datenschutz.de
+          </a>
+        </p>
+      </main>
+    </Layout>
+  );
+}

--- a/src/pages/impressum.tsx
+++ b/src/pages/impressum.tsx
@@ -3,22 +3,97 @@ import Layout from '@theme/Layout';
 
 export default function Impressum(): ReactNode {
   return (
-    <Layout title="Impressum" description="Impressum — Legal notice">
-      <main style={{padding: '4rem 0', maxWidth: '800px', margin: '0 auto'}}>
+    <Layout title="Impressum" description="Impressum – Angaben gemäß § 5 DDG">
+      <main style={{padding: '4rem 2rem', maxWidth: '800px', margin: '0 auto'}}>
         <h1>Impressum</h1>
+
+        <h2>Angaben gemäß § 5 DDG</h2>
+        <p><strong>Betreiber dieser Website:</strong></p>
         <p>
           Vladimir Gribanov<br />
           Filderstr. 54<br />
           70771 Leinfelden-Echterdingen<br />
-          Germany
+          Deutschland
         </p>
         <p>
-          <strong>Contact:</strong><br />
+          <strong>E-Mail:</strong>{' '}
           <a href="mailto:info@hugr-lab.com">info@hugr-lab.com</a>
         </p>
+
+        <hr />
+
+        <h2>Verantwortlich für den Inhalt nach § 55 Abs. 2 RStV</h2>
         <p>
-          <strong>LinkedIn:</strong><br />
-          <a href="https://www.linkedin.com/in/vladimirgribanov/" target="_blank" rel="noopener noreferrer">linkedin.com/in/vladimirgribanov</a>
+          Vladimir Gribanov<br />
+          Filderstr. 54<br />
+          70771 Leinfelden-Echterdingen
+        </p>
+
+        <hr />
+
+        <h2>Projektstatus</h2>
+        <p>
+          Diese Website gehört zu einem nichtkommerziellen Open-Source-Softwareprojekt
+          („Hugr"). Es werden über diese Website keine kostenpflichtigen Dienstleistungen
+          oder Produkte angeboten.
+        </p>
+
+        <hr />
+
+        <h2>Haftung für Inhalte</h2>
+        <p>
+          Die Inhalte unserer Seiten wurden mit größter Sorgfalt erstellt. Für die
+          Richtigkeit, Vollständigkeit und Aktualität der Inhalte können wir jedoch keine
+          Gewähr übernehmen.
+        </p>
+        <p>
+          Als Diensteanbieter sind wir gemäß § 7 Abs. 1 DDG für eigene Inhalte auf diesen
+          Seiten nach den allgemeinen Gesetzen verantwortlich. Nach §§ 8 bis 10 DDG sind
+          wir als Diensteanbieter jedoch nicht verpflichtet, übermittelte oder gespeicherte
+          fremde Informationen zu überwachen.
+        </p>
+
+        <hr />
+
+        <h2>Haftung für Links</h2>
+        <p>
+          Unser Angebot enthält Links zu externen Websites Dritter, auf deren Inhalte wir
+          keinen Einfluss haben. Deshalb können wir für diese fremden Inhalte auch keine
+          Gewähr übernehmen.
+        </p>
+
+        <hr />
+
+        <h2>Urheberrecht</h2>
+        <p>
+          Die durch die Seitenbetreiber erstellten Inhalte und Werke auf diesen Seiten
+          unterliegen dem deutschen Urheberrecht, sofern nicht anders angegeben. Der
+          Quellcode des Projekts steht unter der jeweiligen Open-Source-Lizenz laut{' '}
+          <a
+            href="https://github.com/hugr-lab/hugr"
+            target="_blank"
+            rel="noopener noreferrer">
+            GitHub-Repository
+          </a>
+          .
+        </p>
+
+        <hr />
+
+        <h2>EU-Streitschlichtung</h2>
+        <p>
+          Die Europäische Kommission stellt eine Plattform zur Online-Streitbeilegung (OS)
+          bereit:{' '}
+          <a
+            href="https://ec.europa.eu/consumers/odr/"
+            target="_blank"
+            rel="noopener noreferrer">
+            https://ec.europa.eu/consumers/odr/
+          </a>
+        </p>
+        <p>
+          Wir sind nicht bereit oder verpflichtet, an Streitbeilegungsverfahren vor einer
+          Verbraucherschlichtungsstelle teilzunehmen.
         </p>
       </main>
     </Layout>


### PR DESCRIPTION
## Summary

- Update the Impressum page with the full German legal notice (§ 5 DDG, § 55 RStV) including all 7 required sections: operator info, content responsibility, project status, liability for content/links, copyright, and EU dispute resolution
- Add a new Datenschutzerklärung (DSGVO privacy policy) page at `/datenschutz/` with all 7 required sections: responsible party, GitHub Pages hosting, no-cookies statement, email contact handling, external links, user rights (Art. 15-21), and supervisory authority
- Add Datenschutz link to the site footer alongside the existing Impressum link

## Test plan

- [ ] Navigate to `/impressum/` and verify all 7 sections display with correct personal data
- [ ] Navigate to `/datenschutz/` and verify all 7 DSGVO sections display with correct data
- [ ] Verify footer shows both Impressum and Datenschutz links on every page
- [ ] Verify all external links work (GitHub repo, EU ODR, GitHub Privacy Statement, BW authority)
- [ ] Verify both pages render correctly on mobile (no horizontal scroll)

🤖 Generated with [Claude Code](https://claude.com/claude-code)