### PR TITLE
docs(access-control): document custom claim variables accurately

### DIFF
--- a/docs/4-engine-configuration/5-access-control.md
+++ b/docs/4-engine-configuration/5-access-control.md
@@ -894,7 +894,7 @@ If you previously seeded a filter on every relation edge to isolate a table, rep
 
 ## Authentication Variables
 
-Use authentication variables in filters and default values to create dynamic, user-specific permissions:
+Use authentication variables in filters and default values to create dynamic, user-specific permissions. The following **built-in** variables are always available:
 
 | Variable | Description | Example Value |
 |----------|-------------|---------------|
@@ -905,17 +905,19 @@ Use authentication variables in filters and default values to create dynamic, us
 | `[$auth.auth_type]` | Authentication type | "jwt", "apikey", "oidc" |
 | `[$auth.provider]` | Auth provider | "google", "auth0" |
 
+When a request runs under impersonation, the original identity is also available as `[$auth.impersonated_by_role]`, `[$auth.impersonated_by_user_id]`, and `[$auth.impersonated_by_user_name]`.
+
 ### Custom Claim Variables
 
-You can also access custom claims from JWT/OIDC tokens:
+Any **scalar** claim carried by the authentication credential is exposed as `[$auth.<claim>]`, so you can filter on token-specific attributes such as a tenant or department:
 
 ```graphql
 mutation {
   core {
     insert_role_permissions(data: {
       role: "employee"
-      type_name: "Query"
-      field_name: "departments"
+      type_name: "data-object:query"
+      field_name: "departments"     # the table's GraphQL type name
       filter: {
         department_id: { eq: "[$auth.department_id]" }
       }
@@ -926,6 +928,18 @@ mutation {
   }
 }
 ```
+
+Custom claims come from:
+
+- **JWT / OIDC tokens** — every scalar claim (string, number, boolean) in the verified token. Nested objects and arrays are not exposed.
+- **Managed API keys** — the scalar entries of the `claims` JSON column on the [`api_keys`](../8-references/2-system-reference.md) row (in addition to its `role`/`user_id`/`user_name` identity keys).
+
+Rules:
+
+- Only **scalar** claim values are available; a claim holding an object or array is skipped.
+- A claim **cannot shadow a built-in** — if a token has a claim named `role`, `[$auth.role]` still resolves to the request's effective role, not the raw claim.
+- Custom claims are **not** available under impersonation (the impersonated identity has no token of its own) or for anonymous requests.
+- A placeholder referencing a claim the credential does not carry is left unsubstituted (it will not match rows), so seed filters only on claims your identity provider or API keys are known to issue.
 
 ## Permission Flags
 

--- a/docs/8-references/2-system-reference.md
+++ b/docs/8-references/2-system-reference.md
@@ -89,7 +89,7 @@ API keys for authentication with optional role binding and expiration.
 | `is_temporal` | `Boolean` | Whether the key expires (default: `false`) |
 | `expires_at` | `Timestamp` | Expiration date (required if `is_temporal` is true) |
 | `headers` | `JSON` | HTTP header mapping for extracting user info: `{"role": "x-role", "user_id": "x-user-id", "user_name": "x-user-name"}` |
-| `claims` | `JSON` | Static claims: `{"role": "role", "user_id": "user-id", "user_name": "user-name"}` |
+| `claims` | `JSON` | Static claims. The `role`/`user_id`/`user_name` keys set the identity; any other scalar key is exposed as an `[$auth.<claim>]` permission variable (see [Custom Claim Variables](../4-engine-configuration/5-access-control.md#custom-claim-variables)) |
 
 ### Functions
 


### PR DESCRIPTION
Follow-up to query-engine #130 + #131. The "Custom Claim Variables" section claimed custom JWT/OIDC claims were usable as `[$auth.<claim>]`, but no such mechanism existed — only the fixed built-in set resolved, so those examples silently never matched. Custom claims are now implemented, and this documents how they actually work.

## Changes

- **Custom Claim Variables** section rewritten: scalar claims from JWT/OIDC tokens, and the scalar entries of a managed API key's `claims` column, are exposed as `[$auth.<claim>]`. Rules stated explicitly — scalars only; a claim cannot shadow a built-in; unavailable under impersonation / anonymous; an absent claim is left unsubstituted.
- **Authentication Variables**: lists the impersonation variables.
- **System reference**: `api_keys.claims` documented as identity + custom-claim source, linking to the section.

Build passes with `onBrokenLinks: 'throw'` (fixed one broken `#impersonation` anchor along the way).

Ships alongside the query-engine release that includes #130/#131.

🤖 Generated with [Claude Code](https://claude.com/claude-code)