### PR TITLE
docs: document _dataSources / _dataSource meta queries

### DIFF
--- a/docs/6-querying/2-graphql.md
+++ b/docs/6-querying/2-graphql.md
@@ -296,7 +296,7 @@ query TypeIntrospection {
 
 Standard GraphQL introspection exposes the *generated* schema — hundreds of types including filters, aggregations, and mutation inputs. The `_catalog` meta-query family exposes hugr's **logical data model** directly: the module tree, data objects (tables and views) with their relations, and functions — without reverse-engineering generated type names.
 
-Four meta queries are available (resolved like `__schema`/`__type`, never executed as data queries):
+These meta queries are available (resolved like `__schema`/`__type`, never executed as data queries):
 
 | Query | Returns | Purpose |
 |-------|---------|---------|
@@ -304,6 +304,8 @@ Four meta queries are available (resolved like `__schema`/`__type`, never execut
 | `_module(name: String!)` | `_Module` | Direct module lookup; `""` = root |
 | `_dataObject(name: String!)` | `_DataObject` | Data object by GraphQL type name |
 | `_function(module: String!, name: String!)` | `_Function` | Function/mutation/subscription lookup; `module: ""` = root |
+| `_dataSources` | `[_DataSource!]` | Attached data sources contributing anything visible to the caller |
+| `_dataSource(name: String!)` | `_DataSource` | Data source lookup by name |
 | `_types(scope: _TypeScope = SOURCE)` | `[__Type!]` | Logical-model type definitions: `SOURCE` — residual base types defined by data sources (structs, inputs, enums; excludes data objects, module roots and generated helper types); `SYSTEM` — engine-defined types |
 
 Unknown names resolve to `null` (never an error).
@@ -367,7 +369,7 @@ Relations show the logical link graph from both ends: `FORWARD`/`FK` for the obj
 }
 ```
 
-The meta-types themselves (`_Module`, `_DataObject`, `_DataObjectProperties`, `_Relation`, `_Function` and the enums `_DataObjectType`, `_FunctionType`, `_RelationDirection`, `_RelationKind`) are registered in the schema, so `__type(name: "_Module")` describes them. The four root queries are ordinary system fields of `Query` (single-underscore names, like `_join` and `jq`) — they appear in standard introspection, so GraphiQL autocompletes them and code generators handle them like any other field. GraphQL reserves double-underscore names for the built-in introspection system, which is why the family uses a single underscore.
+The meta-types themselves (`_Module`, `_DataObject`, `_DataObjectProperties`, `_Relation`, `_Function`, `_DataSource` and the enums `_DataObjectType`, `_FunctionType`, `_RelationDirection`, `_RelationKind`) are registered in the schema, so `__type(name: "_Module")` describes them. The meta root queries are ordinary system fields of `Query` (single-underscore names, like `_join` and `jq`) — they appear in standard introspection, so GraphiQL autocompletes them and code generators handle them like any other field. GraphQL reserves double-underscore names for the built-in introspection system, which is why the family uses a single underscore.
 
 `_catalog` results respect the same role-based visibility rules as `__schema` (see below): hidden objects disappear from every path — including other objects' `relations` — while disabled ones stay visible; modules left with no visible content are omitted from `modules` listings.
 

--- a/docs/8-references/2-system-reference.md
+++ b/docs/8-references/2-system-reference.md
@@ -701,7 +701,7 @@ Returns: `NodeVersion!` with fields `version: String!` and `build_date: String!`
 
 ## Logical-Model Introspection (Meta Queries)
 
-Four meta queries expose hugr's logical data model (module tree, data objects with relations, functions) beside the standard `__schema`/`__type` introspection. They are resolved on the metadata path — never planned or executed as data queries — and respect the same role-based visibility rules as `__schema` (hidden elements are absent everywhere, disabled elements stay visible). Unknown names resolve to `null`, never an error. See [GraphQL API — Logical Model Introspection](/docs/querying/graphql#logical-model-introspection-_catalog) for usage examples.
+A family of meta queries exposes hugr's logical data model (module tree, data objects with relations, functions, data sources) beside the standard `__schema`/`__type` introspection. They are resolved on the metadata path — never planned or executed as data queries — and respect the same role-based visibility rules as `__schema` (hidden elements are absent everywhere, disabled elements stay visible). Unknown names resolve to `null`, never an error. See [GraphQL API — Logical Model Introspection](/docs/querying/graphql#logical-model-introspection-_catalog) for usage examples.
 
 ### Meta Queries
 
@@ -711,6 +711,8 @@ Four meta queries expose hugr's logical data model (module tree, data objects wi
 | `_module(name: String!)` | `_Module` | Module by full dotted name; `""` = root module |
 | `_dataObject(name: String!)` | `_DataObject` | Data object by GraphQL type name; `null` for non-data-object types |
 | `_function(module: String!, name: String!)` | `_Function` | Callable member (function/mutation/subscription); `module: ""` = root-level functions |
+| `_dataSources` | `[_DataSource!]` | The attached data sources that contribute anything visible to the caller |
+| `_dataSource(name: String!)` | `_DataSource` | Data source by name; `null` when absent, inactive, or contributing nothing visible |
 | `_types(scope: _TypeScope = SOURCE)` | `[__Type!]` | Logical-model type definitions: `SOURCE` — residual base types defined by data sources (structs, inputs, enums; excludes data objects, module roots and generated helper types); `SYSTEM` — engine-defined types. Compiler-derived types belong to neither scope |
 
 ### `_Module`
@@ -725,6 +727,18 @@ Four meta queries expose hugr's logical data model (module tree, data objects wi
 | `dataObjects` | `[_DataObject!]` | Member data objects (root: objects without `@module`) |
 | `functions` | `[_Function!]` | All callable members, including subscriptions |
 | `queryType` / `mutationType` / `subscriptionType` / `functionType` / `mutationFunctionType` | `__Type` | The module's generated root types (root module: `Query`/`Mutation`/`Subscription`/`Function`/`MutationFunction`); `null` when absent |
+
+### `_DataSource`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | `String!` | Data source name (the `@catalog` name) |
+| `engine` | `String` | The source's engine type string |
+| `description` / `longDescription` | `String` | Descriptions |
+| `readOnly` | `Boolean!` | Mutations are not generated for this source |
+| `asModule` | `Boolean!` | The source is exposed as a module of its own |
+| `isExtension` | `Boolean!` | The source extends other sources' objects |
+| `modules` | `[String!]!` | Modules this source places members in; `""` is the root module |
 
 ### `_DataObject`
 
@@ -781,7 +795,7 @@ Relation SQL (`@join(sql:)` and similar) is never exposed.
 | `_RelationDirection` | `FORWARD`, `BACK` |
 | `_RelationKind` | `FK`, `M2M`, `JOIN` |
 
-All meta-types resolve through standard introspection (`__type(name: "_Module")`), and the four root queries are ordinary system fields of `Query` (single-underscore names, like `_join` and `jq`) visible in `__schema` output — GraphiQL autocomplete and code generators work with them out of the box. GraphQL reserves double-underscore names for the built-in introspection system, which is why the family uses a single underscore.
+All meta-types resolve through standard introspection (`__type(name: "_Module")`), and the meta root queries are ordinary system fields of `Query` (single-underscore names, like `_join` and `jq`) visible in `__schema` output — GraphiQL autocomplete and code generators work with them out of the box. GraphQL reserves double-underscore names for the built-in introspection system, which is why the family uses a single underscore.
 
 ---
 


### PR DESCRIPTION
The `_catalog` meta-query family has **six** root queries plus `_types`. The reference documented four, and the `_DataSource` type was absent from both the system reference and the GraphQL page — so the only way to find the data-source half of the logical model was to read `pkg/catalog/base/system_types.graphql`.

Adds:

- `_dataSources: [_DataSource!]` — attached data sources contributing anything visible to the caller.
- `_dataSource(name: String!): _DataSource` — lookup by name; `null` when the source is absent, inactive, or contributes nothing visible.
- The `_DataSource` field table (`name`, `engine`, descriptions, `readOnly`, `asModule`, `isExtension`, `modules`).

Also drops the "four meta queries" / "four root queries" phrasing in the three places it appeared, and adds `_DataSource` to the list of meta-types reachable through `__type`.

Verified against the SDL; `npm run build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016k9uaQHqunF6isM3XhS5PN