### PR TITLE
docs: _search meta query, and meta-fields are not in introspection

### DIFF
--- a/docs/6-querying/2-graphql.md
+++ b/docs/6-querying/2-graphql.md
@@ -307,6 +307,7 @@ These meta queries are available (resolved like `__schema`/`__type`, never execu
 | `_dataSources` | `[_DataSource!]` | Attached data sources contributing anything visible to the caller |
 | `_dataSource(name: String!)` | `_DataSource` | Data source lookup by name |
 | `_types(scope: _TypeScope = SOURCE)` | `[__Type!]` | Logical-model type definitions: `SOURCE` — residual base types defined by data sources (structs, inputs, enums; excludes data objects, module roots and generated helper types); `SYSTEM` — engine-defined types |
+| `_search(query: String!, …)` | `_SearchResult` | Rank the logical model by relevance to a natural-language description — see [Searching the model](#searching-the-model-_search) |
 
 Unknown names resolve to `null` (never an error).
 
@@ -369,9 +370,65 @@ Relations show the logical link graph from both ends: `FORWARD`/`FK` for the obj
 }
 ```
 
-The meta-types themselves (`_Module`, `_DataObject`, `_DataObjectProperties`, `_Relation`, `_Function`, `_DataSource` and the enums `_DataObjectType`, `_FunctionType`, `_RelationDirection`, `_RelationKind`) are registered in the schema, so `__type(name: "_Module")` describes them. The meta root queries are ordinary system fields of `Query` (single-underscore names, like `_join` and `jq`) — they appear in standard introspection, so GraphiQL autocompletes them and code generators handle them like any other field. GraphQL reserves double-underscore names for the built-in introspection system, which is why the family uses a single underscore.
+These are **meta-fields**, in the same sense `__schema` and `__typename` are: resolved on the metadata path, never planned as data queries, and not members of the served schema. Like `__schema`, they are therefore **not listed** in `Query.fields`, and their result types are not listed in `__schema.types` — so a GraphQL IDE will not autocomplete them and a code generator will not emit them. They remain fully callable, and `__type(name: "_Module")` still describes the meta-types by name, which is how a client probes for the capability:
 
-`_catalog` results respect the same role-based visibility rules as `__schema` (see below): hidden objects disappear from every path — including other objects' `relations` — while disabled ones stay visible; modules left with no visible content are omitted from `modules` listings.
+```graphql
+{ __type(name: "_SearchResult") { name } }   # null on an engine without _search
+```
+
+GraphQL reserves double-underscore names for its own introspection system, which is why the family uses a single underscore.
+
+Being meta-fields also puts them **outside the role permission rules**. Nobody writes a permission row for `__typename`, and the same applies here: a deployment that locks down with a wildcard rule (`type_name: "*"`, `field_name: "*"`) and grants back explicitly does not lose logical-model introspection — nor standard `__schema` introspection, which is subject to the same rule. A **disabled role** is still refused everywhere.
+
+What the meta queries *return* is filtered per role exactly as `__schema` is (see below): hidden objects disappear from every path — including other objects' `relations` — while disabled ones stay visible; modules left with no visible content are omitted from `modules` listings. Only the entry point is exempt from the rules, never the content.
+
+### Searching the Model (`_search`)
+
+`_catalog` answers *what exists*. `_search` answers *what is relevant*: give it a description in your own words and it ranks modules, data sources, data objects, functions and **fields** by meaning.
+
+```graphql
+{
+  _search(query: "customer orders with payment status", kinds: [DATA_OBJECT, FIELD], limit: 20) {
+    lexical
+    lexicalReason
+    hasMore
+    filteredOut
+    items {
+      kind          # MODULE | DATA_SOURCE | DATA_OBJECT | FUNCTION | FIELD
+      name
+      moduleName    # where to nest the query
+      dataSourceName
+      description
+      score         # 0..1, higher is better
+
+      # FIELD hits
+      objectName    # the data object the field belongs to
+      type          # the field's GraphQL type — "String!", "[Int]"
+      hugrType      # what it IS: column | calculated | function | select
+      refObjectName # for a declared @join: the object it navigates to
+
+      # drill down through the ordinary _catalog resolvers, in the same round trip
+      dataObject { name type primaryKey queries { name type } }
+    }
+  }
+}
+```
+
+| Argument | Type | Default | Purpose |
+|----------|------|---------|---------|
+| `query` | `String!` | — | Natural-language description of what you are looking for |
+| `kinds` | `[_SearchKind!]` | all | `MODULE`, `DATA_SOURCE`, `DATA_OBJECT`, `FUNCTION`, `FIELD` |
+| `module` | `String` | `""` (all) | Restrict to this module's subtree. A field hit is scoped by the module of the object that owns it. Data sources are not module-scoped — a source contributes to several |
+| `object` | `String` | — | Restrict FIELD hits to one data object |
+| `limit` / `offset` | `Int` | 50 / 0 | Page size (1–200) and hits to skip |
+| `minScore` | `Float` | — | Drop hits below this score |
+| `includeMcpExcluded` | `Boolean` | `true` | Include fields marked `@exclude_mcp` — an AI-tooling policy, not an access rule |
+
+**Ranking degrades, it does not disappear.** With an embedder configured the ranking is semantic. Without one it falls back to substring matching and says so: `lexical: true`, and `lexicalReason` names the cause — a silent fallback would be indistinguishable from a broken ranking query. Lexical scoring requires **every** word of the query to appear somewhere, so a multi-word query narrows rather than widens; prefer exact terms when `lexical` is set.
+
+**There is no `total`.** The permission filter runs after ranking, so an honest total would mean scanning the whole index on every keystroke. Page with `hasMore`. `filteredOut` counts candidates dropped because the caller may not see them — non-zero distinguishes "nothing matches" from "nothing you may see matches".
+
+**What a FIELD hit can be.** Only four `hugrType` values reach a hit: `column` (a stored value), `calculated` (`@sql`), `function` (`@function_call` or a table-function join) and `select` (a declared `@join`, whose `refObjectName` names where it leads). Relation navigation fields and `@extra_field` companions (`_<f>_part`, `_<f>_measurement`) are generated when the GraphQL type is built rather than stored, so they are never search hits — reach them through `_dataObject`.
 
 ### Role-Based Schema Visibility
 

--- a/docs/6-querying/6-mcp.md
+++ b/docs/6-querying/6-mcp.md
@@ -29,7 +29,7 @@ For embedding-based semantic search across schema descriptions, configure an emb
 | `EMBEDDER_URL` | URL of the embedding service (e.g. an OpenAI-compatible endpoint) | — |
 | `EMBEDDER_VECTOR_SIZE` | Embedding vector dimensions (must match the model output) | — |
 
-When an embedder is configured, schema descriptions are indexed as vectors and [`catalog-search`](#catalog-search) ranks results by semantic relevance. Without one the endpoint still works: search falls back to substring matching and says so, returning `lexical: true` in the result.
+When an embedder is configured, schema descriptions are indexed as vectors and [`catalog-search`](#catalog-search) ranks results by semantic relevance. Without one the endpoint still works: search falls back to substring matching and says so, returning `lexical: true` in the result. The tool is a thin adapter over the engine's [`_search`](/docs/querying/graphql#searching-the-model-_search) meta query, which is also callable directly over GraphQL.
 
 ## Authentication
 
@@ -149,7 +149,7 @@ Find things by **meaning** when you know what you want but not what this deploym
 
 - `next_call` — the exact tool to run next for that hit.
 - `filtered_out` — candidates dropped because the caller may not see them. Non-zero distinguishes "nothing matches" from "nothing you may see matches".
-- `lexical` — `true` when there is no vector index and ranking fell back to substring matching; `lexical_reason` says why.
+- `lexical` — `true` when there is no vector index and ranking fell back to substring matching; `lexical_reason` says why. Lexical scoring requires **every** word of the query to appear somewhere, so a multi-word query narrows rather than widens — prefer exact terms when this is set. Field hits are ranked on this path too.
 - Field hits carry `object` (the data object the field belongs to) and `field_kind`. A `relation` field is a **path**: `ref_object` names the object it navigates to.
 
 #### `catalog-list`

--- a/docs/8-references/2-system-reference.md
+++ b/docs/8-references/2-system-reference.md
@@ -701,7 +701,9 @@ Returns: `NodeVersion!` with fields `version: String!` and `build_date: String!`
 
 ## Logical-Model Introspection (Meta Queries)
 
-A family of meta queries exposes hugr's logical data model (module tree, data objects with relations, functions, data sources) beside the standard `__schema`/`__type` introspection. They are resolved on the metadata path — never planned or executed as data queries — and respect the same role-based visibility rules as `__schema` (hidden elements are absent everywhere, disabled elements stay visible). Unknown names resolve to `null`, never an error. See [GraphQL API — Logical Model Introspection](/docs/querying/graphql#logical-model-introspection-_catalog) for usage examples.
+A family of meta queries exposes hugr's logical data model (module tree, data objects with relations, functions, data sources) beside the standard `__schema`/`__type` introspection. They are resolved on the metadata path — never planned or executed as data queries — and what they *return* respects the same role-based visibility rules as `__schema` (hidden elements are absent everywhere, disabled elements stay visible). Unknown names resolve to `null`, never an error.
+
+They are **meta-fields**, like `__schema` and `__typename`, with the two consequences that follow from it. They are not listed in `Query.fields` and their result types are not listed in `__schema.types`, so tooling that reads the schema does not see them (they stay callable, and `__type(name:)` still resolves the meta-types — that is the capability probe). And they sit **outside the role permission rules**: a wildcard permission row (`type_name: "*"`, `field_name: "*"`) does not remove logical-model introspection, nor standard `__schema` introspection, which is governed by the same rule. Only the entry point is exempt — the content is filtered per role as described above, and a **disabled role** is refused everywhere. See [GraphQL API — Logical Model Introspection](/docs/querying/graphql#logical-model-introspection-_catalog) for usage examples.
 
 ### Meta Queries
 
@@ -714,6 +716,56 @@ A family of meta queries exposes hugr's logical data model (module tree, data ob
 | `_dataSources` | `[_DataSource!]` | The attached data sources that contribute anything visible to the caller |
 | `_dataSource(name: String!)` | `_DataSource` | Data source by name; `null` when absent, inactive, or contributing nothing visible |
 | `_types(scope: _TypeScope = SOURCE)` | `[__Type!]` | Logical-model type definitions: `SOURCE` — residual base types defined by data sources (structs, inputs, enums; excludes data objects, module roots and generated helper types); `SYSTEM` — engine-defined types. Compiler-derived types belong to neither scope |
+| `_search(query: String!, …)` | `_SearchResult` | Rank the logical model by relevance to a natural-language description — modules, data sources, data objects, functions and fields |
+
+#### `_search` arguments
+
+| Argument | Type | Default | Description |
+|----------|------|---------|-------------|
+| `query` | `String!` | — | Natural-language description of what you are looking for |
+| `kinds` | `[_SearchKind!]` | all | `MODULE`, `DATA_SOURCE`, `DATA_OBJECT`, `FUNCTION`, `FIELD` |
+| `module` | `String` | `""` | Restrict to this module's SUBTREE. A field hit takes the module of the object that owns it. `DATA_SOURCE` hits ignore it — a source contributes to several modules |
+| `object` | `String` | — | Restrict `FIELD` hits to one data object |
+| `limit` | `Int` | 50 | Page size, clamped to 1–200 |
+| `offset` | `Int` | 0 | Hits to skip |
+| `minScore` | `Float` | — | Drop hits scoring below this (0–1) |
+| `includeMcpExcluded` | `Boolean` | `true` | Include fields marked `@exclude_mcp` — an AI-tooling policy, not an access rule |
+
+#### `_SearchResult`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `items` | `[_SearchHit!]!` | The page, ordered by score |
+| `limit` / `offset` | `Int!` | The page actually served |
+| `hasMore` | `Boolean!` | More hits past this page, or candidates left unverified |
+| `filteredOut` | `Int!` | Candidates dropped because the caller may not see them — non-zero distinguishes "nothing matches" from "nothing you may see matches" |
+| `lexical` | `Boolean!` | `true` when ranking fell back to substring matching |
+| `lexicalReason` | `String` | Why the vector index was unusable; `null` when it was used |
+
+There is deliberately **no total**: the permission filter runs after ranking, so an honest total would mean scanning the whole index on every query.
+
+#### `_SearchHit`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `kind` | `_SearchKind!` | What the hit is |
+| `name` | `String!` | Module: dotted path. Data object: GraphQL type name. Function: field name in its module. Field: field name on its object |
+| `moduleName` | `String!` | Owning module — required to nest the query; `""` for `DATA_SOURCE` |
+| `dataSourceName` | `String` | Owning data source; `null` for `MODULE` |
+| `description` | `String` | Curated description where one exists, the source's otherwise |
+| `score` | `Float!` | 0–1, higher is better. Lexical scores are coarse |
+| `objectName` | `String` | `FIELD` only: the data object the field belongs to |
+| `type` | `String` | `FIELD` only: the field's GraphQL type, SDL spelling (`String!`, `[Int]`) |
+| `hugrType` | `String` | `FIELD` only: what the field IS — same vocabulary as `__Field.hugr_type` |
+| `refObjectName` | `String` | `FIELD` only: for a declared `@join`, the data object it navigates to |
+| `module` / `dataObject` / `function` / `dataSource` | meta types | Drill-down through the ordinary `_catalog` resolvers — exactly one is non-null, matching `kind`. Costs nothing unless selected |
+| `field` | `__Field` | `FIELD` only: the field definition |
+
+**Ranking and its fallback.** With an embedder the ranking is semantic, over the annotation vectors the engine seeds and `reindex_embeddings` refreshes. Without one it falls back to substring matching and reports it (`lexical`, `lexicalReason`) — a silent fallback would be indistinguishable from a broken ranking query. Lexical scoring requires **every** word of the query to appear, so a multi-word query narrows rather than widens.
+
+**What a `FIELD` hit can be.** Only four `hugrType` values reach a hit: `column` (a stored value), `calculated` (`@sql`), `function` (`@function_call` or a table-function join) and `select` (a declared `@join`, with `refObjectName` set). Relation navigation fields and `@extra_field` companions are generated when the GraphQL type is built rather than stored, so they are never search hits.
+
+**Permissions.** Ranking reads the annotation index with full access — the index lives in the `core.entity_*` views, and a role may hold no rights on them — but nothing reaches the caller without passing the same visibility predicates `_catalog` applies. Search cannot surface anything `_dataObject` would then refuse to show.
 
 ### `_Module`
 
@@ -817,7 +869,7 @@ The logical model is also queryable as plain rows: the `core` module publishes `
 | `core.entity_types` | Residual source-defined types as raw SDL |
 | `core.entity_annotations` | The curation overlay: descriptions, audit fields, the embedding vector — including *orphans* (curation of currently unloaded entities) and load-time seed rows |
 
-The views apply **no row-level permission filtering** — they are an *administrative* surface. Access is governed by the ordinary data-object permission rules applied to the views themselves (grant, hide or disable `core.entity_*` per role exactly like any other data object); request-scoped, permission-filtered catalog introspection is exclusively the job of the `_catalog` meta queries. The views' only built-in filter is the **data-source state semi-join**: entities of unloaded, disabled or suspended data sources are hidden (their rows stay in storage — unloading is a flag flip, and loading an unchanged source back is instant; rows are physically deleted only when a source is *unregistered*). Effective descriptions COALESCE the annotations overlay over the source-provided text; raw SQL (view definitions, computed-field expressions, join conditions, default expressions, function SQL) is never projected. When an embedder is configured the views project the annotation-joined `vec` and carry `@embeddings` — semantic search pushes down into the CoreDB engine (pgvector/HNSW on PostgreSQL), and the engine **seeds** vector-only annotation rows from the source-schema descriptions during every load, so a just-connected source is semantically searchable immediately; curation and summarization refine on top and always win. Relation-generated navigation fields are curated as ordinary **field** annotations keyed by the owning object and the field name (`source.source_field` / `destination.destination_field` — set with `annotate_field`); `entity_relations` projects the curated text in its `*_field_description` columns.
+The views apply **no row-level permission filtering** — they are an *administrative* surface. Access is governed by the ordinary data-object permission rules applied to the views themselves (grant, hide or disable `core.entity_*` per role exactly like any other data object); request-scoped, permission-filtered catalog introspection is exclusively the job of the `_catalog` meta queries (`_search` included). The views' only built-in filter is the **data-source state semi-join**: entities of unloaded, disabled or suspended data sources are hidden (their rows stay in storage — unloading is a flag flip, and loading an unchanged source back is instant; rows are physically deleted only when a source is *unregistered*). Effective descriptions COALESCE the annotations overlay over the source-provided text; raw SQL (view definitions, computed-field expressions, join conditions, default expressions, function SQL) is never projected. When an embedder is configured the views project the annotation-joined `vec` and carry `@embeddings` — semantic search pushes down into the CoreDB engine (pgvector/HNSW on PostgreSQL), and the engine **seeds** vector-only annotation rows from the source-schema descriptions during every load, so a just-connected source is semantically searchable immediately; curation and summarization refine on top and always win. Relation-generated navigation fields are curated as ordinary **field** annotations keyed by the owning object and the field name (`source.source_field` / `destination.destination_field` — set with `annotate_field`); `entity_relations` projects the curated text in its `*_field_description` columns.
 
 ---
 


### PR DESCRIPTION
Documents the logical-model search added in query-engine#153, and corrects what the GraphQL page said about the `_catalog` family.

## New: `_search`

`docs/6-querying/2-graphql.md` gains a **Searching the Model** section — the argument table, an example with drill-down, and the three things a caller has to know:

- ranking degrades rather than disappears (`lexical` / `lexicalReason`), and lexical scoring requires **every** word of the query, so a multi-word query narrows rather than widens;
- there is deliberately no `total` — the permission filter runs after ranking, so an honest one would mean scanning the whole index per keystroke. Page with `hasMore`; `filteredOut` distinguishes "nothing matches" from "nothing you may see matches";
- what a FIELD hit can be: only `column`, `calculated`, `function` and `select` reach one, because relation navigation fields and `@extra_field` companions are generated when the GraphQL type is built rather than stored.

`docs/8-references/2-system-reference.md` gains the reference tables: `_search` arguments, `_SearchResult`, `_SearchHit`, and a note that the ranking read is privileged while nothing reaches the caller without passing the same predicates `_catalog` applies.

## Correction

The GraphQL page claimed the meta root queries

> appear in standard introspection, so GraphiQL autocompletes them and code generators handle them like any other field.

They no longer do. They are meta-fields, like `__schema`, and are absent from `Query.fields` and `__schema.types`. They stay callable, and `__type(name:)` still resolves the meta-types — that is the capability probe, and it is now written down.

## Worth an operator's attention

The family sits **outside the role permission rules**. A wildcard permission row used to remove logical-model introspection and standard `__schema` introspection along with it; it no longer does. Only the entry point is exempt — content is filtered per role as before, and a disabled role is refused everywhere. Both the GraphQL page and the system reference say so now.

## MCP page

`catalog-search` is a thin adapter over `_search`, with a link to it. Noted that field hits are ranked on the lexical path too — they were dropped there before.

Site builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016k9uaQHqunF6isM3XhS5PN